### PR TITLE
bugfix: load correct data for vehicles that are not leasable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "athlon-flex-api"
-version = "0.1.7"
+version = "0.1.8"
 description = "Unofficial API client for Athlon Flex Lease"
 authors = [
     { name = "Aucke Bos", email = "hedge-cannon-aged@duck.com" }

--- a/src/athlon_flex_api/models/vehicle.py
+++ b/src/athlon_flex_api/models/vehicle.py
@@ -98,7 +98,8 @@ class Vehicle(BaseModel):
         return f"{self.make} {self.model} {self.type} {self.modelYear}"
 
     def details_request_params_from_profile(
-        self, profile: Profile
+        self,
+        profile: Profile,
     ) -> dict[str, str | int]:
         """Return the request parameters for loading the details of the vehicle.
 


### PR DESCRIPTION
When a vehicle is not leasable, we cannot properly load the details when logged in. We should logout, but still provide the Profile properties in the request. This allows us to still load the details according to profile properties (like #kmh per month).